### PR TITLE
Update sync, acquire_sequence, and release_sequence.

### DIFF
--- a/alloy/ptx.als
+++ b/alloy/ptx.als
@@ -143,12 +143,12 @@ fun cause : Op->Op {
 }
 
 fun sync : Op->Op {
-  release_sequence.^observation.acquire_sequence
+  strong[release_sequence.^observation.acquire_sequence]
 }
 
 fun release_sequence : Op->Op {
-  (WriteRelease <: optional[po_loc] :> Write)
-  + (ReleaseFences <: ^po :> Write)
+  strong[WriteRelease <: optional[po_loc] :> Write]
+  + strong[ReleaseFences <: ^po :> Write]
 }
 
 /* There are two definitions: the original version was the raw definition
@@ -162,8 +162,8 @@ fun observation : Op->Op {
 // fact { observation.rmw.observation in observation }
 
 fun acquire_sequence : Op->Op {
-  (Read <: optional[po_loc] :> ReadAcquire)
-  /* 2) A Read followed by an AcquireFence (or greater) */
+  strong[Read <: optional[po_loc] :> ReadAcquire]
+  + strong[Read <: ^po :> AcquireFences]
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/Release_acquire_pattern.test
+++ b/tests/Release_acquire_pattern.test
@@ -1,0 +1,16 @@
+.global x;
+.global y;
+
+d0.b0.t0 {
+  st.weak [y], 1;
+  st.release.sys [x], 1;
+  st.relaxed.sys [x], 2;
+}
+
+d0.b1.t0 {
+  ld.relaxed.sys r1, [x];
+  fence.acq_rel.sys;
+  ld.weak r3, [y];
+}
+
+permit (r1 == 2 && r3 == 0) as my_test;


### PR DESCRIPTION
This commit addresses three updates:
1. Make the write following release operation/release- fence to be strong; make the read followed by acquire operation/acquire-fence to be strong. This update follows the introduction of docummentation: https://docs.nvidia.com/cuda/parallel-thread-execution/#release-acquire-patterns.
2. Incorporate the model comments by including "A Read followed by an AcquireFence (or greater)" in the acquire pattern, (based on the update of 1) aligning with the documented guidelines.
3. Based on the documentation, the first operation of the release pattern and the last operation of the acquire pattern should be morally strong to make the two patterns synchronized. Besides, the second write in the release pattern and the first read in the acquire pattern should be strong. Updating the sync with strong could apply this restriction. The last two bugs conceals each other. We add a litmus test, the expected result is SAT which is correct with the current model. But the model does not fully follow the documentation. Once the acquire fence rule added, the litmus test gives the wrong result. Then the second fix that also follows the documentation is needed.