### PR TITLE
Add constant-proxy grammar and tests

### DIFF
--- a/src/grammar.lark
+++ b/src/grammar.lark
@@ -6,6 +6,7 @@ addresses: address_decl*
 address_decl: "." space     string (/physically/ "aliases" string)? ";"
             | "." /texref/  string  /virtually/  "aliases" string   ";"
             | "." /surfref/ string  /virtually/  "aliases" string   ";"
+            | "." /conref/  string  /virtually/  "aliases" string   ";"
 
 !space: "global" | "shared"
 

--- a/tests/CoWR.test
+++ b/tests/CoWR.test
@@ -1,6 +1,7 @@
 .global x;
 .texref t virtually aliases x;
 .surfref s virtually aliases x;
+.conref c virtually aliases x;
 
 d0.b0.t0 {
   $0, 1;
@@ -14,7 +15,9 @@ $$
 
 st   [x] |                                           | ld   | [x] | assert | ==
 st   [x] |                                           | suld | [s] | permit | !=
+st   [x] |                                           | ldc  | [c] | permit | !=
 st   [x] | fence.proxy.surface;                      | suld | [s] | assert | ==
+st   [x] | fence.proxy.constant;                     | ldc  | [c] | assert | ==
 sust [s] |                                           | ld   | [x] | permit | !=
 sust [s] | fence.proxy.surface;                      | ld   | [x] | assert | ==
 sust [s] |                                           | suld | [s] | assert | ==
@@ -22,3 +25,4 @@ sust [s] | fence.proxy.surface;                      | tld  | [t] | permit | !=
 sust [s] | fence.proxy.texture;                      | tld  | [t] | permit | !=
 sust [s] | fence.proxy.texture; fence.proxy.surface; | tld  | [t] | permit | !=
 sust [s] | fence.proxy.surface; fence.proxy.texture; | tld  | [t] | assert | ==
+sust [s] | fence.proxy.surface; fence.proxy.constant;| ldc  | [c] | assert | ==

--- a/tests/MP_cta.test
+++ b/tests/MP_cta.test
@@ -1,6 +1,7 @@
 .global x;
 .texref t virtually aliases x;
 .surfref s virtually aliases x;
+.conref c virtually aliases x;
 .global flag;
 
 d0.b0.t0 {
@@ -25,18 +26,24 @@ sust [s] |                                           |                          
 sust [s] |                                           |                                           | suld | [s] | assert | ==
 
 st   [x] | fence.proxy.surface;                      |                                           | suld | [s] | assert | ==
+st   [x] | fence.proxy.constant;                     |                                           | ldc  | [c] | assert | ==
+st   [x] |                                           | fence.proxy.constant;                     | ldc  | [c] | assert | ==
 sust [s] | fence.proxy.surface;                      |                                           | ld   | [x] | assert | ==
 sust [s] | fence.proxy.surface;                      |                                           | tld  | [t] | permit | !=
 sust [s] | fence.proxy.texture;                      |                                           | tld  | [t] | permit | !=
 sust [s] | fence.proxy.texture; fence.proxy.surface; |                                           | tld  | [t] | permit | !=
 sust [s] | fence.proxy.surface; fence.proxy.texture; |                                           | tld  | [t] | assert | ==
+sust [s] | fence.proxy.surface; fence.proxy.constant;|                                           | ldc  | [c] | assert | ==
 
 sust [s] | fence.proxy.texture;                      | fence.proxy.surface;                      | tld  | [t] | permit | !=
 sust [s] | fence.proxy.surface;                      | fence.proxy.texture;                      | tld  | [t] | assert | ==
+sust [s] | fence.proxy.constant;                     | fence.proxy.surface;                      | ldc  | [c] | permit | !=
+sust [s] | fence.proxy.surface;                      | fence.proxy.constant;                     | ldc  | [c] | assert | ==
 
 st   [x] |                                           | fence.proxy.surface;                      | suld | [s] | assert | ==
 sust [s] |                                           | fence.proxy.surface;                      | ld   | [x] | assert | ==
 sust [s] |                                           | fence.proxy.surface;                      | tld  | [t] | permit | !=
 sust [s] |                                           | fence.proxy.texture;                      | tld  | [t] | permit | !=
+sust [s] |                                           | fence.proxy.constant;                     | ldc  | [c] | permit | !=
 sust [s] |                                           | fence.proxy.texture; fence.proxy.surface; | tld  | [t] | permit | !=
 sust [s] |                                           | fence.proxy.surface; fence.proxy.texture; | tld  | [t] | assert | ==

--- a/tests/MP_gpu.test
+++ b/tests/MP_gpu.test
@@ -1,6 +1,7 @@
 .global x;
 .texref t virtually aliases x;
 .surfref s virtually aliases x;
+.conref c virtually aliases x;
 .global flag;
 
 d0.b0.t0 {
@@ -21,10 +22,12 @@ $$
 
 st   [x] |                                           |                                           | ld   | [x] | assert | ==
 st   [x] |                                           |                                           | suld | [s] | permit | !=
+st   [x] |                                           |                                           | ldc  | [c] | permit | !=
 sust [s] |                                           |                                           | ld   | [x] | permit | !=
 sust [s] |                                           |                                           | suld | [s] | permit | !=
 
 st   [x] | fence.proxy.surface;                      |                                           | suld | [s] | permit | !=
+st   [x] | fence.proxy.constant;                     |                                           | ldc  | [c] | permit | !=
 sust [s] | fence.proxy.surface;                      |                                           | ld   | [x] | assert | ==
 sust [s] | fence.proxy.surface;                      |                                           | tld  | [t] | permit | !=
 sust [s] | fence.proxy.texture;                      |                                           | tld  | [t] | permit | !=


### PR DESCRIPTION
This PR adds support for constant proxy locations and includes additional tests primarily derived from Figure 8 in the paper 'Mixed-Proxy Extensions for the NVIDIA PTX Memory Consistency Model'.